### PR TITLE
forward message and just update payload

### DIFF
--- a/neo4j.js
+++ b/neo4j.js
@@ -77,8 +77,11 @@ module.exports = function (RED) {
               msg.payload.push(processRecord(item.get(0)))
             })
             node.send([null, msg])
-          } else {
+          } else if (result.records.length == 1) {
             msg.payload = processRecord(result.records[0].get(0))
+            node.send([msg, null])
+          } else {
+            msg.payload = null
             node.send([msg, null])
           }
         })

--- a/neo4j.js
+++ b/neo4j.js
@@ -23,14 +23,8 @@ module.exports = function (RED) {
         } else {
           params = msg.params
         }
-        var scalar_result = {
-          payload: null
-        }
-        const resultPromise = session.run(query, params)
 
-        var array_result = {
-          payload: []
-        }
+        const resultPromise = session.run(query, params)
 
         function processInteger (integer) {
           if (integer.constructor.name === 'Integer') {
@@ -78,13 +72,14 @@ module.exports = function (RED) {
         resultPromise.then(result => {
           session.close()
           if (result.records.length > 1) {
+            msg.payload = [];
             result.records.forEach(function (item, index, array) {
-              array_result.payload.push(processRecord(item.get(0)))
+              msg.payload.push(processRecord(item.get(0)))
             })
-            node.send([null, array_result])
+            node.send([null, msg])
           } else {
-            scalar_result.payload = processRecord(result.records[0].get(0))
-            node.send([scalar_result, null])
+            msg.payload = processRecord(result.records[0].get(0))
+            node.send([msg, null])
           }
         })
       })

--- a/neo4j.js
+++ b/neo4j.js
@@ -73,12 +73,20 @@ module.exports = function (RED) {
           session.close()
           if (result.records.length > 1) {
             msg.payload = [];
-            result.records.forEach(function (item, index, array) {
-              msg.payload.push(processRecord(item.get(0)))
+            result.records.forEach(function (record, index, array) {
+              let itm = {};
+              record.forEach(function (item, index, array) {
+                itm[index] = processRecord(item)
+              })
+              msg.payload.push(itm)
             })
             node.send([null, msg])
           } else if (result.records.length == 1) {
-            msg.payload = processRecord(result.records[0].get(0))
+            let itm = {};
+            result.records[0].forEach(function (item, index, array) {
+              itm[index] = processRecord(item)
+            })
+            msg.payload = itm
             node.send([msg, null])
           } else {
             msg.payload = null

--- a/neo4j.js
+++ b/neo4j.js
@@ -82,6 +82,9 @@ module.exports = function (RED) {
             node.send([msg, null])
           }
         })
+        .catch(err => {
+            node.error(err, msg);
+        })
       })
     } else {
       node.status({


### PR DESCRIPTION
These changes allow the messag to be pipelined, so that it can be used in a more complex flow. For example you can now use it in a HTTP flow, which requires the msg.req and msg.res to be pipelined.