### PR TITLE
Feature/concurrent sessions

### DIFF
--- a/neo4j.html
+++ b/neo4j.html
@@ -6,7 +6,7 @@
             server: {value:"", type:"neo4j-bolt-server", required:true},
             name: {value:""},
             query: {value: ""},
-            sessions: {value: 10},
+            sessions: {value: 10, required: true},
             database: {value: ""}
         },
         inputs:1,

--- a/neo4j.html
+++ b/neo4j.html
@@ -10,7 +10,8 @@
             database: {value: ""}
         },
         inputs:1,
-        outputs:2,
+        outputs:3,
+        outputLabels: ["single", "array", "no session available - retry later"],
         icon: "neo4j.png",
         label: function() {
             return this.name||"neo4j-bolt";

--- a/neo4j.html
+++ b/neo4j.html
@@ -5,7 +5,9 @@
         defaults: {
             server: {value:"", type:"neo4j-bolt-server", required:true},
             name: {value:""},
-            query: {value: ""}
+            query: {value: ""},
+            sessions: {value: 10},
+            database: {value: ""}
         },
         inputs:1,
         outputs:2,
@@ -27,6 +29,12 @@
         <br/>
         <label for="node-input-query"><i class="icon-tag"></i>Cypher Query</label>
         <textarea id="node-input-query" placeholder="MATCH (o:Object {attrib: 'value'}) RETURN o" style="width: 70%;"></textarea>
+        <br/>
+        <label for="node-input-sessions"><i class="icon-tag"></i>Concurrent sessions</label>
+        <input type="text" id="node-input-sessions" placeholder="10" />
+        <br />
+        <label for="node-input-database"><i class="icon-tag"></i> Database</label>
+        <input type="text" id="node-input-database" placeholder="database">
     </div>
 </script>
 

--- a/neo4j.html
+++ b/neo4j.html
@@ -49,6 +49,7 @@
       <ul>
         <li><code>1:</code>If the query returns a single record, it is returned in output #1 as an object with the Neo4j Record (Node, Relationship, Path, Integer) fields in <code>msg.payload</code></li>
         <li><code>2:</code>If the query returns a multiple records, they are returned in output #2 as an array of objects in <code>msg.payload</code></li>
+        <li><code>2:</code>If there are no available sessions, the msg is passed untouched for the calling flow to decide on what to do, e.g. retry</li>
       </ul>
     </p>
 </script>

--- a/neo4j.js
+++ b/neo4j.js
@@ -128,7 +128,7 @@ module.exports = function (RED) {
     }
 
     node.on('close', function () {
-      sessions.map(s => s.session.close())
+      sessions.map(s => s.close())
       driver.close()
     })
   }

--- a/neo4j.js
+++ b/neo4j.js
@@ -5,117 +5,119 @@ module.exports = function (RED) {
     var node = this
 
     var sessions = []
+    var readySessionList = []
 
     node.server = RED.nodes.getNode(config.server)
 
     const driver = node.server.driver
 
+    // set up a list of sessions for later use, to avoid session allocation error later on
     for( i=0; i<config.sessions; i++){
       try {
-        sessions.push( {
-          ready: true,
-          session: driver.session({database: config.database})
-        })  
+        sessions.push(driver.session())
+        readySessionList.push(i)
       } catch (err) {
         console.log(err)
         break
       }
     }
 
-    if (sessions.length > 0) {
+    if (readySessionList.length > 0) {
       node.status({
         fill: 'green',
         shape: 'dot',
-        text: 'node-red:common.status.connected'
+        text: `connected: ${readySessionList.length} sesions`
       })
       node.on('input', function (msg) {
         var query = config.query || msg.query
 
-        var session
-        while (null === session.find(s => s.ready === true)) {
+        if( readySessionList.length > 0 ){
+          // remove and use a session
+          var readySession = readySessionList.shift()
+          var boltSession = sessions[readySession]
+
+          let params = null
+          if (typeof (msg.params) === 'string') {
+            params = JSON.parse(msg.params)
+          } else {
+            params = msg.params
+          }
+
+          function processInteger (integer) {
+            if (integer.constructor.name === 'Integer') {
+              return integer.toNumber()
+            }
+            return integer
+          }
+
+          function processRecord (record) {
+            if (record.constructor.name === 'Integer') {
+              return record.toNumber()
+            }
+
+            if (record.constructor.name === 'Path') {
+              record.start.identity = processInteger(record.start.identity)
+              record.end.identity = processInteger(record.end.identity)
+              record.segments = record.segments.map(segment => {
+
+                segment.start.identity = processInteger(segment.start.identity)
+                segment.end.identity = processInteger(segment.end.identity)
+
+                segment.relationship.identity = processInteger(segment.relationship.identity)
+                segment.relationship.start = processInteger(segment.relationship.start)
+                segment.relationship.end = processInteger(segment.relationship.end)
+
+                return segment
+              })
+              return record
+            }
+
+            if (record.constructor.name === 'Relationship') {
+              record.identity = processInteger(record.identity)
+              record.start = processInteger(record.start)
+              record.end = processInteger(record.end)
+              return record
+            }
+
+            if (record.constructor.name === 'Node') {
+              record.identity = processInteger(record.identity)
+              return record
+            }
+
+            return record
+          }
           
-        }
-        session.ready = false
-        boltSession = session.session
-        let params = null
-        if (typeof (msg.params) === 'string') {
-          params = JSON.parse(msg.params)
-        } else {
-          params = msg.params
-        }
-
-        function processInteger (integer) {
-          if (integer.constructor.name === 'Integer') {
-            return integer.toNumber()
-          }
-          return integer
-        }
-
-        function processRecord (record) {
-          if (record.constructor.name === 'Integer') {
-            return record.toNumber()
-          }
-
-          if (record.constructor.name === 'Path') {
-            record.start.identity = processInteger(record.start.identity)
-            record.end.identity = processInteger(record.end.identity)
-            record.segments = record.segments.map(segment => {
-
-              segment.start.identity = processInteger(segment.start.identity)
-              segment.end.identity = processInteger(segment.end.identity)
-
-              segment.relationship.identity = processInteger(segment.relationship.identity)
-              segment.relationship.start = processInteger(segment.relationship.start)
-              segment.relationship.end = processInteger(segment.relationship.end)
-
-              return segment
-            })
-            return record
-          }
-
-          if (record.constructor.name === 'Relationship') {
-            record.identity = processInteger(record.identity)
-            record.start = processInteger(record.start)
-            record.end = processInteger(record.end)
-            return record
-          }
-
-          if (record.constructor.name === 'Node') {
-            record.identity = processInteger(record.identity)
-            return record
-          }
-
-          return record
-        }
-        
-        boltSession.run(query, params).then(result => {
-          if (result.records.length > 1) {
-            msg.payload = [];
-            result.records.forEach(function (record, index, array) {
+          boltSession.run(query, params).then(result => {
+            if (result.records.length > 1) {
+              msg.payload = [];
+              result.records.forEach(function (record, index, array) {
+                let itm = {};
+                record.forEach(function (item, index, array) {
+                  itm[index] = processRecord(item)
+                })
+                msg.payload.push(itm)
+              })
+              node.send([null, msg, null])
+            } else if (result.records.length == 1) {
               let itm = {};
-              record.forEach(function (item, index, array) {
+              result.records[0].forEach(function (item, index, array) {
                 itm[index] = processRecord(item)
               })
-              msg.payload.push(itm)
-            })
-            node.send([null, msg])
-          } else if (result.records.length == 1) {
-            let itm = {};
-            result.records[0].forEach(function (item, index, array) {
-              itm[index] = processRecord(item)
-            })
-            msg.payload = itm
-            node.send([msg, null])
-          } else {
-            msg.payload = null
-            node.send([msg, null])
-          }
-          session.ready = true
-        })
-        .catch(err => {
-            session.ready = true
+              msg.payload = itm
+              node.send([msg, null, null])
+            } else {
+              node.send([null, null, null])
+            }
+          })
+          .catch(err => {
             node.error(err, msg);
-        })
+          }).finally(() => {
+            readySessionList.push(readySession) 
+          })
+        } else {
+          // no sessions available, send the message out on the third  port for further processing bty caller
+          node.send([null, null, msg])
+        }
       })
     } else {
       node.status({

--- a/neo4j.js
+++ b/neo4j.js
@@ -14,7 +14,7 @@ module.exports = function (RED) {
     // set up a list of sessions for later use, to avoid session allocation error later on
     for( i=0; i<config.sessions; i++){
       try {
-        sessions.push(driver.session())
+        sessions.push(driver.session({database: config.database || 'neo4j'}))
         readySessionList.push(i)
       } catch (err) {
         console.log(err)


### PR DESCRIPTION
Use a pool of sessions to avoid problems with session acquisition for high rate of requests.
1. On node start-up create a pool of sessions.
2. For each message grab a session, execute the query and put it back
3. if no session is available pass the msg object unchanged to the 3rd output and let the flow decide if and when to retry.